### PR TITLE
fix(extractor): avoid self-contained typedef

### DIFF
--- a/dbconstructor/functionextractor/extract.py
+++ b/dbconstructor/functionextractor/extract.py
@@ -147,6 +147,9 @@ def extract_one_file(src_file):
                 r"typedef\s+([\w\s\*\_]+)\s([\w\_]+)", item_json["typedef"]
             )
             if len(matched_typedef) > 0:
+                type_replace, type_orig = matched_typedef[0]
+                if re.search(rf"\b{re.escape(type_orig)}\b", type_replace):
+                    continue
                 to_replace_typedef_list.append(matched_typedef[0])
         elif "global" in item_json:
             if "struct" not in item_json["global"]:


### PR DESCRIPTION
Fix #9 

This PR detects and skips self-contained typedefs (where `type_replace `already contains `type_orig `as a word).

This ensures that system-level typedefs such as `pthread_t ` are preserved without expansion.